### PR TITLE
Change IDF dependency to >=5.3

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -42,7 +42,7 @@ files:
     - "platform.txt"
     - "programmers.txt"
 dependencies:
-  idf: ">=5.1,<5.2"
+  idf: ">=5.3"
   # mdns 1.2.1 is necessary to build H2 with no WiFi
   espressif/mdns:
     version: "^1.2.3"


### PR DESCRIPTION
This will allow Arduino 3.1 to build as a component
